### PR TITLE
Fix qube name ordering

### DIFF
--- a/ui/authorization-dialog.ui
+++ b/ui/authorization-dialog.ui
@@ -103,7 +103,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
-                <property name="label" translatable="yes">The qube &lt;b&gt;%(server)s&lt;/b&gt; wants to access the following folder on qube &lt;b&gt;%(client)s&lt;/b&gt;:</property>
+                <property name="label" translatable="yes">The qube &lt;b&gt;%(client)s&lt;/b&gt; wants to access the following folder on qube &lt;b&gt;%(server)s&lt;/b&gt;:</property>
                 <property name="use_markup">True</property>
               </object>
               <packing>


### PR DESCRIPTION
As far as I could see, the names of the client and server qube were switched around in the UI when requesting access.

This PR fixes that.

Signed-off-by: Atrate <Atrate@protonmail.com>