### PR TITLE
docs: add instruction to install `policycoreutils`

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Download and install to your template:
 
 Download and install to your dom0:
 
+* `policycoreutils` using `sudo qubes-dom0-update policycoreutils`
 * the latest `qubes-shared-folders-dom0` `noarch` package
 
 Shut off your template qube and restart any qubes you plan to share folders


### PR DESCRIPTION
Fixes #20. Perhaps you also want to add that package explicitly as a dependency in addition to the binary paths `/sbin/fixfiles`, `/sbin/restorecon`,	`/usr/sbin/semodule`.