### PR TITLE
fix: remove `DESTDIR=/usr`

### DIFF
--- a/doc/building-from-source.md
+++ b/doc/building-from-source.md
@@ -116,9 +116,9 @@ built).  These commands will require a few dependencies on the system you
 build on, including `cargo` from the Rust collection.
 
 Then copy *the source tree* to a folder in your template (preserving
-timestamps), and then run `make install-client install-server DESTDIR=/usr`
-within that folder of your template.  Note that this will modify your
-template's root file system permanently.
+timestamps), and then run `make install-client install-server` within that 
+folder of your template.  Note that this will modify your template's root
+file system permanently.
 
 You will still need to build and install the dom0 package for your dom0.
 Follow the Fedora instructions above to do so.


### PR DESCRIPTION
This was resulting in files installed in `/usr/usr/`. Fixes #22.