### PR TITLE
install Python package to `/usr/` not `/usr/local/`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DATADIR=/usr/share
 DESTDIR=
 PROGNAME=qubes-shared-folders
 PYTHON=/usr/bin/python3
-SITEPACKAGES=$(shell python3 -Ic "import sysconfig; print(sysconfig.get_path('platlib', vars={'platbase': '/usr', 'base': '/usr'}))")
+SITEPACKAGES=$(shell python3 -Ic "import sysconfig; print(sysconfig.get_path('platstdlib', vars={'platbase': '/usr', 'base': '/usr'}))")
 
 .PHONY: clean install-client install-dom0 install-py black test mypy unit
 


### PR DESCRIPTION
Fixes #24. Seems to work for me, but not sure if there's a better way to do this.